### PR TITLE
Requests session

### DIFF
--- a/pymfl/api/MFLAPIClient.py
+++ b/pymfl/api/MFLAPIClient.py
@@ -3,7 +3,7 @@ from abc import ABC
 from typing import Optional, Any
 
 import requests
-from requests import Response
+from requests import Response, Session
 
 from pymfl.api.config import APIConfig
 from pymfl.enum import APIResponseType
@@ -63,8 +63,7 @@ class MFLAPIClient(ABC):
     @classmethod
     def __get_response_for_year_and_league_id(cls, *, url: str, year: int, league_id: str) -> Response:
         api_config = cls.__API_CONFIG.get_config_by_year_and_league_id(year=year, league_id=league_id)
-        cookies = {"MFL_LAST_LEAGUE_ID": api_config.league_id, "MFL_USER_ID": api_config.mfl_user_id}
-        response = requests.get(url, cookies=cookies)
+        response = api_config.session.get(url)
         response.raise_for_status()
         return response
 
@@ -73,7 +72,8 @@ class MFLAPIClient(ABC):
         if body is None:
             body = dict()
         as_xml = kwargs.pop("as_xml")
-        response = requests.post(url, data=body)
+        session: Session = kwargs.pop("session")
+        response = session.post(url, data=body)
         response.raise_for_status()
         if as_xml:
             xml_response = ET.fromstring(response.content)

--- a/pymfl/api/SessionAPIClient.py
+++ b/pymfl/api/SessionAPIClient.py
@@ -1,13 +1,18 @@
 from pymfl.api.MFLAPIClient import MFLAPIClient
+from pymfl.exception import MFLAPIClientException
 from pymfl.util import ConfigReader
+
+from requests import Session
 
 
 class SessionAPIClient(MFLAPIClient):
     __LOGIN_ROUTE = ConfigReader.get("api", "login_route")
 
     @classmethod
-    def get_mfl_user_id(cls, *, year: int, username: str, password: str) -> str:
+    def get_mfl_user_id(cls, *, year: int, username: str, password: str, session: Session) -> str:
         url = cls._build_route(cls._MFL_APP_BASE_URL, year, cls.__LOGIN_ROUTE)
         url = cls._add_filters(url, ("USERNAME", username), ("PASSWORD", password), ("XML", 1))
-        response = cls._post(url, as_xml=True)
-        return response.attrib["MFL_USER_ID"]  # TODO: do some error handling here
+        response = cls._post(url, session=session, as_xml=True)
+        if "MFL_USER_ID" not in response.attrib or response.attrib["MFL_USER_ID"] == "":
+            raise MFLAPIClientException(f"Login failed: user={username}")
+        return response.attrib["MFL_USER_ID"]

--- a/test/test_api/test_CommonLeagueInfoAPIClient.py
+++ b/test/test_api/test_CommonLeagueInfoAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import CommonLeagueInfoAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_league_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_rules_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -53,7 +55,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_rosters_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -67,7 +69,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_free_agents_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -81,7 +83,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_schedule_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -95,7 +97,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_calendar_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -109,7 +111,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_playoff_brackets_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -124,7 +126,7 @@ class TestCommonLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_playoff_bracket_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_CommunicationsAPIClient.py
+++ b/test/test_api/test_CommunicationsAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import CommunicationsAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestCommunicationsAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestCommunicationsAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_league_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestCommunicationsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_message_board_thread_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -55,7 +57,7 @@ class TestCommunicationsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_polls_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_DraftAndAuctionAPIClient.py
+++ b/test/test_api/test_DraftAndAuctionAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import DraftAndAuctionAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestDraftAndAuctionAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestDraftAndAuctionAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_draft_results_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestDraftAndAuctionAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_auction_results_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -53,7 +55,7 @@ class TestDraftAndAuctionAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_my_draft_list_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_FantasyContentAPIClient.py
+++ b/test/test_api/test_FantasyContentAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import FantasyContentAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_players_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_player_profile_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -55,7 +57,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_all_rules_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -69,7 +71,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_player_ranks_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -83,7 +85,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_adp_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -97,7 +99,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_aav_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -111,7 +113,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_top_adds_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -125,7 +127,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_top_drops_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -139,7 +141,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_top_starters_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -153,7 +155,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_top_trades_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -167,7 +169,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_top_owns_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -181,7 +183,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_site_news_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -195,7 +197,7 @@ class TestFantasyContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_who_should_i_start_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_LeaguePlayersAPIClient.py
+++ b/test/test_api/test_LeaguePlayersAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import LeaguePlayersAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_player_roster_status_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -41,7 +43,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_contest_players_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -55,7 +57,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_my_watch_list_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -69,7 +71,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_salaries_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -83,7 +85,7 @@ class TestLeaguePlayersAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_salary_adjustments_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_NFLContentAPIClient.py
+++ b/test/test_api/test_NFLContentAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import NFLContentAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestNFLContentAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestNFLContentAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_injuries_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestNFLContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_nfl_schedule_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -53,7 +55,7 @@ class TestNFLContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_nfl_bye_weeks_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -67,7 +69,7 @@ class TestNFLContentAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_points_allowed_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_OtherLeagueInfoAPIClient.py
+++ b/test/test_api/test_OtherLeagueInfoAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import OtherLeagueInfoAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_future_draft_picks_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -40,7 +42,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_accounting_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -54,7 +56,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_pool_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -68,7 +70,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_survivor_pool_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -82,7 +84,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_abilities_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -96,7 +98,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_appearance_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -110,7 +112,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_rss_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -124,7 +126,7 @@ class TestOtherLeagueInfoAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_ics_happy_path(self, mock_requests_get):
         mock_bytes = b"test_bytes"
 

--- a/test/test_api/test_ScoringAndResultsAPIClient.py
+++ b/test/test_api/test_ScoringAndResultsAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import ScoringAndResultsAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_league_standings_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -40,7 +42,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_weekly_results_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -54,7 +56,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_live_scoring_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -68,7 +70,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_player_scores_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -82,7 +84,7 @@ class TestScoringAndResultsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_projected_scores_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_TransactionsAPIClient.py
+++ b/test/test_api/test_TransactionsAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import TransactionsAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_transactions_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_pending_waivers_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -53,7 +55,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_pending_trades_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -67,7 +69,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_trade_bait_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -81,7 +83,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_assets_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"

--- a/test/test_api/test_UserFunctionsAPIClient.py
+++ b/test/test_api/test_UserFunctionsAPIClient.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import mock
 
+from requests import Session
+
 from pymfl.api import UserFunctionsAPIClient
 from pymfl.api.config import APIConfig
 from test.helper.helper_classes import MockResponse
@@ -14,7 +16,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
     __TEST_USER_AGENT_NAME = "user_agent_name"
 
     @classmethod
-    @mock.patch("requests.post")
+    @mock.patch.object(Session, "post")
     def setUpClass(cls, mock_requests_post):
         mock_xml = """<status MFL_USER_ID="test_user_id=">OK</status>"""
         mock_response = MockResponse(dict(), 200, content=mock_xml)
@@ -25,7 +27,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
                                                     password=cls.__TEST_PASSWORD,
                                                     user_agent_name=cls.__TEST_USER_AGENT_NAME)
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_my_leagues_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"
@@ -39,7 +41,7 @@ class TestTransactionsAPIClient(unittest.TestCase):
         self.assertEqual(1, len(response.keys()))
         self.assertEqual("v", response["k"])
 
-    @mock.patch("requests.get")
+    @mock.patch.object(Session, "get")
     def test_get_league_search_results_happy_path(self, mock_requests_get):
         mock_dict = {
             "k": "v"


### PR DESCRIPTION
Let callers pass in a requests session object, and use that for cookie storage instead of passing around the MFL_USER_ID cookie. Fixes #10 